### PR TITLE
chore(deps): replace strings as per the updates

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -32,7 +32,7 @@ spec:
                 make build
             - name: check-registry
               resources: {}
-            - image: uses:spring-financial-group/DevOps/pipelines/build-scan-push.yaml@main
+            - image: uses:spring-financial-group/mqube-pipeline-catalog/tasks/build-scan-push/build-scan-push.yaml@main
               name: ""
               resources: {}
             - name: promote-changelog

--- a/.lighthouse/jenkins-x/semanticcheck.yaml
+++ b/.lighthouse/jenkins-x/semanticcheck.yaml
@@ -24,7 +24,7 @@ spec:
               resources: {}
             - name: jx-variables
               resources: {}
-            - image: uses:spring-financial-group/DevOps/pipelines/semantic-check.yaml@main
+            - image: uses:spring-financial-group/mqube-pipeline-catalog/tasks/tools/semantic-check.yaml@main
               name: ""
               resources: {}
   podTemplate: {}


### PR DESCRIPTION
This pull request replaces the following string pairs:

- File: .lighthouse/jenkins-x/release.yaml
  - `uses:spring-financial-group/DevOps/pipelines/build-scan-push.yaml` → `uses:spring-financial-group/mqube-pipeline-catalog/tasks/build-scan-push/build-scan-push.yaml`
- File: .lighthouse/jenkins-x/semanticcheck.yaml
  - `uses:spring-financial-group/DevOps/pipelines/semantic-check.yaml` → `uses:spring-financial-group/mqube-pipeline-catalog/tasks/tools/semantic-check.yaml`
